### PR TITLE
Enabling Student Course_Enrollment on admin page

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -277,7 +277,7 @@ class CourseEnrollmentForm(forms.ModelForm):
 
 
 @admin.register(CourseEnrollment)
-class CourseEnrollmentAdmin(DisableEnrollmentAdminMixin, admin.ModelAdmin):
+class CourseEnrollmentAdmin(admin.ModelAdmin):
     """ Admin interface for the CourseEnrollment model. """
     list_display = ('id', 'course_id', 'mode', 'user', 'is_active',)
     list_filter = ('mode', 'is_active',)


### PR DESCRIPTION
**Description:**
By default the Student Course_Enrollment model is not visible on the admin page. Removing the Mixin to disable it.

**Clickup Task:**
[Enable Coruse Enrollment on the LMS admin page](https://app.clickup.com/t/7wnuku)