### PR TITLE
Adding fixes for Python 2 to 3 port

### DIFF
--- a/lms/djangoapps/challenges/models.py
+++ b/lms/djangoapps/challenges/models.py
@@ -137,7 +137,7 @@ class ChallengeSubmission(models.Model):
         
         Returns the `answer_id`
         """
-        answer_id = state['input_state'].keys()[0]
+        answer_id = list(state['input_state'].keys())[0]
         return answer_id
     
     def create_correct_map(self, answer_id):
@@ -180,7 +180,6 @@ class ChallengeSubmission(models.Model):
 
         student_activity = StudentModule.objects.get(student=self.student,
             module_state_key=block_location, course_id=course_key)
-        
         student_activity.state = self.update_module_state(student_activity)
         student_activity.grade = grade
         student_activity.max_grade = 1.0


### PR DESCRIPTION
**Description:**
Fixing issues with Challenges webhook caused by porting open edx from Python 2 to 3.

**Clickup Task:**
[Add challenges / webhooks to new build](https://app.clickup.com/t/7pn779)

**Manual Tests:**
- Cloned an existing repl.it and changed the webhook to point to my juniper dev instance
- Added the updated repl link to a course
- Submitted an answer to the new repl
- Webhook correctly redirected back to the dev instance's challenge webhook
- The correct result (both passed and not passed) saved in the database.