### PR TITLE
Removing unecessary session cookie middleware and auth backends

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -557,13 +557,6 @@ AWS_S3_CUSTOM_DOMAIN = 'SET-ME-PLEASE (ex. bucket-name.s3.amazonaws.com)'
 
 EDX_ROOT_URL = ''
 
-# use the ratelimit backend to prevent brute force attacks
-AUTHENTICATION_BACKENDS = [
-    'rules.permissions.ObjectPermissionBackend',
-    'openedx.core.djangoapps.oauth_dispatch.dot_overrides.backends.EdxRateLimitedAllowAllUsersModelBackend',
-    'bridgekeeper.backends.RulePermissionBackend',
-]
-
 STATIC_ROOT_BASE = '/edx/var/edxapp/staticfiles'
 
 # License for serving content in China
@@ -668,13 +661,11 @@ MIDDLEWARE = [
     'django_sites_extensions.middleware.RedirectMiddleware',
 
     # Instead of SessionMiddleware, we use a more secure version
-    # 'django.contrib.sessions.middleware.SessionMiddleware',
-    'openedx.core.djangoapps.safe_sessions.middleware.SafeSessionMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
 
     'method_override.middleware.MethodOverrideMiddleware',
 
-    # Instead of AuthenticationMiddleware, we use a cache-backed version
-    'openedx.core.djangoapps.cache_toolbox.middleware.CacheBackedAuthenticationMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
 
     'student.middleware.UserStandingMiddleware',
     'openedx.core.djangoapps.contentserver.middleware.StaticContentServer',
@@ -916,7 +907,6 @@ COURSES_WITH_UNSAFE_CODE = []
 DEBUG = False
 SESSION_COOKIE_SECURE = False
 SESSION_SAVE_EVERY_REQUEST = False
-SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleSerializer'
 SESSION_COOKIE_DOMAIN = ""
 SESSION_COOKIE_NAME = 'cisessionid' # avoids conflict with Wordpress bug
 

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -38,8 +38,6 @@ def get_env_setting(setting):
 
 DEBUG = False
 
-SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
-
 # IMPORTANT: With this enabled, the server must always be behind a proxy that
 # strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
 # a user can fool our server into thinking it was an https connection.

--- a/lms/djangoapps/ci_program/models.py
+++ b/lms/djangoapps/ci_program/models.py
@@ -127,7 +127,7 @@ class Program(TimeStampedModel):
             return 'emails/default/{0}'.format(template_type_name), "LMS"
 
     def __str__(self):
-        return self.name
+        return "<%s: %s>" % (self.name, self.program_code)
 
     def get_program_descriptor(self, request):
         """
@@ -553,7 +553,7 @@ class CourseCode(models.Model):
         return self.key.split('+')
 
     def __str__(self):
-        return self.display_name
+        return "<%s: %s>" % (self.key, self.display_name)
 
 
 class ProgramCourseCode(TimeStampedModel):
@@ -569,4 +569,4 @@ class ProgramCourseCode(TimeStampedModel):
         app_label = 'ci_program'
 
     def __str__(self):
-        return self.course_code.key
+        return "<%s: %s>" % (self.program.name, self.course_code.key)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -786,12 +786,6 @@ DEFAULT_TEMPLATE_ENGINE_DIRS = DEFAULT_TEMPLATE_ENGINE['DIRS'][:]
 
 ###############################################################################################
 
-AUTHENTICATION_BACKENDS = [
-    'rules.permissions.ObjectPermissionBackend',
-    'openedx.core.djangoapps.oauth_dispatch.dot_overrides.backends.EdxRateLimitedAllowAllUsersModelBackend',
-    'bridgekeeper.backends.RulePermissionBackend',
-]
-
 STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
 MAX_FILEUPLOADS_PER_INPUT = 20
 
@@ -1157,7 +1151,6 @@ DEBUG = False
 USE_TZ = True
 SESSION_COOKIE_SECURE = False
 SESSION_SAVE_EVERY_REQUEST = False
-SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleSerializer'
 SESSION_COOKIE_DOMAIN = ""
 SESSION_COOKIE_NAME = 'cisessionid' # avoids conflict with Wordpress bug
 
@@ -1521,12 +1514,9 @@ MIDDLEWARE = [
     'django_sites_extensions.middleware.RedirectMiddleware',
 
     # Instead of SessionMiddleware, we use a more secure version
-    # 'django.contrib.sessions.middleware.SessionMiddleware',
-    'openedx.core.djangoapps.safe_sessions.middleware.SafeSessionMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
 
-    # Instead of AuthenticationMiddleware, we use a cached backed version
-    #'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'openedx.core.djangoapps.cache_toolbox.middleware.CacheBackedAuthenticationMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
 
     'student.middleware.UserStandingMiddleware',
     'openedx.core.djangoapps.contentserver.middleware.StaticContentServer',

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -52,8 +52,6 @@ def get_env_setting(setting):
 DEBUG = False
 DEFAULT_TEMPLATE_ENGINE['OPTIONS']['debug'] = False
 
-SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
-
 # IMPORTANT: With this enabled, the server must always be behind a proxy that
 # strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
 # a user can fool our server into thinking it was an https connection.


### PR DESCRIPTION
This addresses the issues with logging in reported by igor and a problem blocking deployment of Juniper LMS.

It also allows for simpler authentication across separate services, as the cookie rewriting in the middleware is not something we need.