### PR TITLE
Adding PickleSerializer back in to fix the problem bug

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -907,6 +907,7 @@ COURSES_WITH_UNSAFE_CODE = []
 DEBUG = False
 SESSION_COOKIE_SECURE = False
 SESSION_SAVE_EVERY_REQUEST = False
+SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleSerializer'
 SESSION_COOKIE_DOMAIN = ""
 SESSION_COOKIE_NAME = 'cisessionid' # avoids conflict with Wordpress bug
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1151,6 +1151,7 @@ DEBUG = False
 USE_TZ = True
 SESSION_COOKIE_SECURE = False
 SESSION_SAVE_EVERY_REQUEST = False
+SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleSerializer'
 SESSION_COOKIE_DOMAIN = ""
 SESSION_COOKIE_NAME = 'cisessionid' # avoids conflict with Wordpress bug
 


### PR DESCRIPTION
**Description:**
The programme team is facing an issue with problems not being properly displayed on Studio. This seems to have been caused by removing the PickleSerializer. Adding it back in to fix the problem.

**Testing:**
Tested on local dev environement. Error message no longer appearing and the problems are displaying correctly.

**ClickUp Task:**
[Problems not correctly showing up on Studio](https://app.clickup.com/t/agy9h8)