### PR TITLE
Fix old Django module name in export

### DIFF
--- a/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
+++ b/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
@@ -81,7 +81,7 @@ def days_into_data(first_active, completion_timestamps):
 
 def format_module_field(module_name, suffix):
     # TODO: Rename module name once there is no student who can view it
-    if module_name == 'Full Stack Frameworks with Django - retiring Aug 31':
+    if 'Full Stack Frameworks' in module_name:
         return 'full_stack_frameworks_with_django' + suffix
     return module_name.lower().replace(' ', '_') + suffix
 


### PR DESCRIPTION
**Description:**
Change the way we are checking and renaming the old retiring django module for the export to succeed.

**Click Up:**
[LMS export fix for old django module](https://app.clickup.com/t/b8xxp9)