### PR TITLE
Adjust for email address capitalization being different between LMS and CRM

### DIFF
--- a/lms/djangoapps/learning_success/management/commands/create_lms_records.sql
+++ b/lms/djangoapps/learning_success/management/commands/create_lms_records.sql
@@ -13,9 +13,9 @@ CREATE TABLE lms_records (
     `pathway` text DEFAULT NULL,
     `source_platform` text DEFAULT NULL,
     -- current_programme is the current value of the CRM Programme_Id field
-    `current_programme` text NOT NULL,
+    `current_programme` text NULL,
     -- current_lms_version is the current value of the CRM LMS_Version field
-    `current_lms_version` text NOT NULL,
+    `current_lms_version` text NULL,
     `state` VARCHAR(255) NOT NULL,
     CHECK (`partial_student_data` IS NULL OR JSON_VALID(`partial_student_data`)),
     CHECK (`final_student_data` IS NULL OR JSON_VALID(`final_student_data`))

--- a/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
+++ b/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
@@ -307,13 +307,13 @@ def convert_student_data_to_dataframe(student_data, source_platform, pathway,
     DataFrame in its entirety
     
     Returns the created DataFrame """
-    crm_programme_ids = {student.get('Email'): student.get('Programme_ID')
+    crm_programme_ids = {student.get('Email').lower(): student.get('Programme_ID')
                          for student in zoho_data}
     crm_lms_version = {
-        student.get('Email'): format_lms_version(student.get('LMS_Version'))
+        student.get('Email').lower(): format_lms_version(student.get('LMS_Version'))
             for student in zoho_data}
     formatted_student_data = [
-        {'email': student_email,
+        {'email': student_email.lower(),
          'partial_student_data': json.dumps(student, default=str)}
         for student_email, student in student_data.items()]
 

--- a/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
+++ b/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
@@ -308,10 +308,10 @@ def convert_student_data_to_dataframe(student_data, source_platform, pathway,
     
     Returns the created DataFrame """
     crm_programme_ids = {student.get('Email').lower(): student.get('Programme_ID')
-                         for student in zoho_data}
+                         for student in zoho_data if student.get('Email')}
     crm_lms_version = {
         student.get('Email').lower(): format_lms_version(student.get('LMS_Version'))
-            for student in zoho_data}
+            for student in zoho_data if student.get('Email')}
     formatted_student_data = [
         {'email': student_email.lower(),
          'partial_student_data': json.dumps(student, default=str)}


### PR DESCRIPTION
**Description:**
Some lookups for `Programme_ID` and `LMS_Version` values from the CRM results in NULL values if they 1) don't have values in the CRM and 2) their email address is different to the one in the LMS. Thus, in order to avoid losing data, this PR adjusts the table to allow for NULL values and casts the email addresses to lowercase to avoid missing values because of capitalization.

**Clickup Task:**
[Missing `current_programme` and `current_lms_version` values because of mismatching emails because of different capitalization](https://app.clickup.com/t/gz4yup)

**Testing:**
Tested udpated export locally which successfully exports the data and missing information is populated.