### PR TITLE
Update challenge helper for activity exports

### DIFF
--- a/lms/djangoapps/learning_success/management/commands/challenges_helper.py
+++ b/lms/djangoapps/learning_success/management/commands/challenges_helper.py
@@ -9,7 +9,6 @@ Example data construct returned:
 }
 """
 from django.conf import settings
-from django.contrib.auth.models import User
 
 from challenges.models import Challenge
 
@@ -23,23 +22,9 @@ from lms.djangoapps.learning_success.management.commands.export_all_breadcrumbs 
 DEFAULT_CHALLENGE = {
     'passed': 0,
     'num_attempts': 0,
-    'attempted': 0,
-    'unattempted': 0
-}
-DEFAULT_SKILL = {
-    'achieved': 0,
-    'total': 0,
-}
-CHALLENGE_PATTERN = r"[\/]challenges[\/]([a-zA-Z0-9]*)[\"|']"
-
-
-def increment_student_skill_tags(student_skills, skill_tags):
-    """ Increments the student's achieved skill tags based on the skill tags
-    of the challenge
-
-    Modifies dict inplace """
-    for skill in skill_tags:
-        student_skills[skill]['achieved'] += 1
+    'attempted': 0,'passed': 0,
+    'num_attempts': 0,
+    'attempted': 0
 
 
 def generate_default_skills(skill_tags):
@@ -79,7 +64,6 @@ def extract_challenge_submissions():
 
 def get_all_published_blocks():
     """ Queries the mongo database for all published blocks and returns the
-
     results as a list of dicts"""
     query = [
         {
@@ -153,7 +137,6 @@ def get_all_published_blocks():
     return [block for block in all_blocks]
 
 
-
 def extract_all_challenges_from_blocks(programme):
     """ Retrieves all blocks, filters out any that are not a problem or if
     the content does not include a challenge_id (extracted based on regex)
@@ -163,8 +146,8 @@ def extract_all_challenges_from_blocks(programme):
     course_codes = [course_code.key
                     for course_code in programme.course_codes.all()]
     all_blocks = get_all_published_blocks()
-
     problems = {}
+
     for course in all_blocks:
         if course.get('course_id') not in course_codes:
             continue
@@ -207,18 +190,19 @@ def aggregate_challenge_results_per_student(enrolled_students,
         for module_level in
         set(programme_challenges.values())
     }
-
     challenge_results = {}
+
     for student_id, student_email in enrolled_students.items():
         student_challenges = deepcopy(default_challenges)
+
         for challenge_id, module_level in programme_challenges.items():
             submission = all_submissions.get((challenge_id,  student_id))
+
             if not submission:
                 student_challenges[module_level]['unattempted'] += 1
             else:
                 student_challenges[module_level][
                     'num_attempts'] += submission['attempts']
-
                 if submission.get('passed'):
                     student_challenges[module_level]['passed'] += 1
                 else:
@@ -228,9 +212,11 @@ def aggregate_challenge_results_per_student(enrolled_students,
             module_level: json.dumps(challenge_data)
             for module_level, challenge_data in student_challenges.items()
         }
+
         # TODO: Add skill tag calculation back in (currently not used in AMOS)
         challenge_results[student_email]['student_skills'] = json.dumps(
             DEFAULT_SKILL)
+
     return challenge_results
 
 

--- a/lms/djangoapps/learning_success/management/commands/challenges_helper.py
+++ b/lms/djangoapps/learning_success/management/commands/challenges_helper.py
@@ -8,15 +8,14 @@ Example data construct returned:
     }
 }
 """
-from django.conf import settings
-
-from challenges.models import Challenge
-
 from copy import deepcopy
 from collections import Counter, defaultdict
 import json
 import re
 
+from django.conf import settings
+
+from challenges.models import Challenge
 from lms.djangoapps.learning_success.management.commands.export_all_breadcrumbs import get_safely  # noqa: E501
 
 DEFAULT_CHALLENGE = {

--- a/lms/djangoapps/learning_success/management/commands/challenges_helper.py
+++ b/lms/djangoapps/learning_success/management/commands/challenges_helper.py
@@ -21,9 +21,23 @@ from lms.djangoapps.learning_success.management.commands.export_all_breadcrumbs 
 DEFAULT_CHALLENGE = {
     'passed': 0,
     'num_attempts': 0,
-    'attempted': 0,'passed': 0,
-    'num_attempts': 0,
-    'attempted': 0
+    'attempted': 0,
+    'unattempted': 0
+}
+DEFAULT_SKILL = {
+    'achieved': 0,
+    'total': 0,
+}
+CHALLENGE_PATTERN = r"[\/]challenges[\/]([a-zA-Z0-9]*)[\"|']"
+
+
+def increment_student_skill_tags(student_skills, skill_tags):
+    """ Increments the student's achieved skill tags based on the skill tags
+    of the challenge
+
+    Modifies dict inplace """
+    for skill in skill_tags:
+        student_skills[skill]['achieved'] += 1
 
 
 def generate_default_skills(skill_tags):

--- a/lms/djangoapps/learning_success/management/commands/challenges_helper.py
+++ b/lms/djangoapps/learning_success/management/commands/challenges_helper.py
@@ -1,16 +1,36 @@
-""" Module handles any challenge or challenge tag related logic """
+""" Module handles any challenge or challenge tag related logic
+
+Example data construct returned:
+{
+    'user@example.codeinstitute.net': {
+        'cpl_06_20_required': '{"passed": 1, "num_attempts": 3, "attempted": 0, "unattempted": 0}',
+        'student_skills': '{"Python": {"achieved": 1, "total": 1}}'
+    }
+}
+"""
+from django.conf import settings
+from django.contrib.auth.models import User
+
 from challenges.models import Challenge
 
 from copy import deepcopy
 from collections import Counter, defaultdict
 import json
+import re
 
 from lms.djangoapps.learning_success.management.commands.export_all_breadcrumbs import get_safely  # noqa: E501
 
+DEFAULT_CHALLENGE = {
+    'passed': 0,
+    'num_attempts': 0,
+    'attempted': 0,
+    'unattempted': 0
+}
 DEFAULT_SKILL = {
     'achieved': 0,
     'total': 0,
 }
+CHALLENGE_PATTERN = r"[\/]challenges[\/]([a-zA-Z0-9]*)[\"|']"
 
 
 def increment_student_skill_tags(student_skills, skill_tags):
@@ -34,68 +54,197 @@ def generate_default_skills(skill_tags):
     return default_skills
 
 
-def index_challenge_to_module_and_level():
-    """ Collects all Challeges in the LMS
+def extract_challenge_submissions():
+    """ Queries the mongodb for all challenge submissions and aggregates the
+    results in such a way that we get the most recent submission's passed
+    status (T/F), number of attempts grouped by challenge and user
 
-    TODO: Consider limiting it only to get a speficied program
+    Returns a dict with a tuple of (challenge_id, user_id) as key and
+    the submission dict as value """
+    MONGO_DB = settings.MONGO_CLIENT['challenges']
+    mongo_submissions = MONGO_DB['submissions'].aggregate([
+        { "$sort": {"submitted":-1, "challenge_id": 1, "user_id": 1} },
+        { "$group": {
+                "_id" : "$challenge_id",
+                "submitted": {"$last": "$submitted" },
+                "user_id": {"$first": "$user_id" },
+                "passed": {"$first": "$passed" },
+                "attempts": {"$sum": 1}
+            }
+        }
+    ])
+    return {(str(submission['_id']), submission['user_id']): submission
+            for submission in mongo_submissions}
 
-    Returns a dict of all challenges with its PK and category"""
-    challenge_index = {}
-    skill_tags = {}
-    for challenge in Challenge.objects.all():
-        module = challenge.block_locator.split('+')[1].lower()
-        module_level = "_".join((module, challenge.level)).lower()
-        challenge_index[challenge.pk] = module_level
-        skill_tags[challenge.pk] = [tag.name for tag in challenge.tags.all()]
-    return challenge_index, skill_tags
+
+def get_all_published_blocks():
+    """ Queries the mongo database for all published blocks and returns the
+
+    results as a list of dicts"""
+    query = [
+        {
+            "$project": {
+                "root_definition_id": "$versions.published-branch",
+                "course_id": {
+                    "$concat": [
+                        "$org",
+                        "+",
+                        "$course",
+                        "+",
+                        "$run"
+                    ]
+                }
+            }
+        },
+        {
+            "$lookup": {
+                "from": "modulestore.structures",
+                "localField": "root_definition_id",
+                "foreignField": "_id",
+                "as": "structures"
+            }
+        },
+        {
+            "$project": {
+                "blocks": "$structures.blocks",
+                "course_id": 1
+            }
+        },
+        {
+            "$unwind": "$blocks"
+        },
+        {
+            "$project": {
+                "blocks.block_id": 1,
+                "blocks.block_type": 1,
+                "blocks.definition": 1,
+                "blocks.fields": 1,
+                "course_id": 1,
+            }
+        },
+        {
+            "$unwind": "$blocks"
+        },
+        {
+            "$lookup": {
+                "from": "modulestore.definitions",
+                "localField": "blocks.definition",
+                "foreignField": "_id",
+                "as": "definition_content",
+            }
+        },
+        {
+            "$group": {
+                "_id": "$course_id",
+                "course_id": {"$first": "$course_id"},
+                "blocks": {
+                    "$push": {
+                        "block_id": "$blocks.block_id",
+                        "block_type": "$blocks.block_type",
+                        "fields": "$blocks.fields",
+                        "definition_content": "$definition_content.fields.data"
+                    }
+                }
+            }
+        }
+    ]
+    db = settings.MONGO_DB['modulestore.active_versions']
+    all_blocks = db.aggregate(query)
+    return [block for block in all_blocks]
 
 
-def single_student_challenge_history(student, challenge_counter,
-                                     challenge_index, skill_tags,
-                                     default_skills):
-    """ Creates the challenge history for one student
 
-    Returns a dict with with passed, attempted and unattempted counts """
-    challenge_activities = {module: defaultdict(int) for module
-                            in challenge_counter.keys()}
-    student_skills = deepcopy(default_skills)
+def extract_all_challenges_from_blocks(programme):
+    """ Retrieves all blocks, filters out any that are not a problem or if
+    the content does not include a challenge_id (extracted based on regex)
 
-    for submission in student.challengesubmission_set.all():
-        module = challenge_index[submission.challenge_id]
-        challenge_tags = skill_tags[submission.challenge_id]
-        if submission.passed:
-            challenge_activities[module]['passed'] += 1
-            increment_student_skill_tags(student_skills, challenge_tags)
-        else:
-            challenge_activities[module]['attempted'] += 1
-        challenge_activities[module]['num_attempts'] += submission.attempts
+    Returns a dict with course code, challenge_id and combination between
+    course identifier and level of challenge (e.g. required) """
+    course_codes = [course_code.key
+                    for course_code in programme.course_codes.all()]
+    all_blocks = get_all_published_blocks()
 
-    for module_level, total_challenges in challenge_counter.items():
-        activities = challenge_activities[module_level]
-        activities['unattempted'] = (
-            total_challenges - activities['passed'] - activities['attempted'])
-        activities.setdefault('num_attempts', 0)
+    problems = {}
+    for course in all_blocks:
+        if course.get('course_id') not in course_codes:
+            continue
 
-    challenge_activities = {
-        module: json.dumps(challenges)
-        for module, challenges in challenge_activities.items()
+        for block in course.get('blocks'):
+            if block.get('block_type') != 'problem':
+                continue
+
+            definition_content = block.get('definition_content')
+            content = definition_content[0] if definition_content else ''
+            matches = re.findall(CHALLENGE_PATTERN, content) if content else []
+            challenge_id = matches[0] if matches else None
+
+            if not challenge_id:
+                continue
+
+            course_id = course.get('course_id')
+            module = course_id.split('+')[1].lower()
+            # We only have required challenges at the moment
+            module_level = "_".join((module, 'required')).lower()
+            problems[challenge_id] = module_level
+
+    return problems
+
+
+def aggregate_challenge_results_per_student(enrolled_students,
+                                            programme_challenges,
+                                            all_submissions):
+    """ Iterates through all students and challenges for a specific programme
+    and increments the data points we track
+
+    unattempted = incremented if no submission found
+    attempted = incremented if a challenge submission found, but not passed
+    passed = incremented if a challenge submission found and passed
+    num_attempts = incremented if a challege is attempted or passed
+
+    Returns the a dict with the results for all students in a programme """
+    default_challenges = {
+        module_level: deepcopy(DEFAULT_CHALLENGE)
+        for module_level in
+        set(programme_challenges.values())
     }
-    challenge_activities['student_skills'] = json.dumps(student_skills)
-    return challenge_activities
+
+    challenge_results = {}
+    for student_id, student_email in enrolled_students.items():
+        student_challenges = deepcopy(default_challenges)
+        for challenge_id, module_level in programme_challenges.items():
+            submission = all_submissions.get((challenge_id,  student_id))
+            if not submission:
+                student_challenges[module_level]['unattempted'] += 1
+            else:
+                student_challenges[module_level][
+                    'num_attempts'] += submission['attempts']
+
+                if submission.get('passed'):
+                    student_challenges[module_level]['passed'] += 1
+                else:
+                    student_challenges[module_level]['attempted'] += 1
+
+        challenge_results[student_email] = {
+            module_level: json.dumps(challenge_data)
+            for module_level, challenge_data in student_challenges.items()
+        }
+        # TODO: Add skill tag calculation back in (currently not used in AMOS)
+        challenge_results[student_email]['student_skills'] = json.dumps(
+            DEFAULT_SKILL)
+    return challenge_results
 
 
-def extract_all_student_challenges(program):
-    """ Calculates the historical challenge data for all students
+def extract_challenges_for_programme_from_mongodb(programme):
+    """ Extract aggregated challenge data for all enrolled students in a
+    specified programme
 
-    Returns a dict with email and challenge history for each student """
-    challenge_index, skill_tags = index_challenge_to_module_and_level()
-    default_skills = generate_default_skills(skill_tags)
-    challenge_counter = Counter(challenge_index.values())
-    students = program.enrolled_students.all()
-    challenge_history = {
-        student.email: single_student_challenge_history(
-            student, challenge_counter, challenge_index, skill_tags,
-            default_skills)
-        for student in students.prefetch_related('challengesubmission_set')
-    }
-    return challenge_history
+    Challenges are based on the currently published challenges in the CMS
+
+    Returns the a dict with the results for all students in a programme """
+    enrolled_students = {student.id: student.email
+                         for student in programme.enrolled_students.all()}
+    programme_challenges = extract_all_challenges_from_blocks(programme)
+    all_submissions = extract_challenge_submissions()
+
+    return aggregate_challenge_results_per_student(
+        enrolled_students, programme_challenges, all_submissions)

--- a/lms/djangoapps/learning_success/management/commands/challenges_helper.py
+++ b/lms/djangoapps/learning_success/management/commands/challenges_helper.py
@@ -1,5 +1,8 @@
 """ Module handles any challenge or challenge tag related logic
 
+TODO: Restructure the data by adding another field for the name, rather than
+keying the dictionary to it
+
 Example data construct returned:
 {
     'user@example.codeinstitute.net': {

--- a/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
+++ b/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
@@ -5,7 +5,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 from opaque_keys.edx.locator import CourseLocator
 from xmodule.modulestore.django import modulestore
-from lms.djangoapps.learning_success.management.commands.challenges_helper import extract_all_student_challenges
+from lms.djangoapps.learning_success.management.commands.challenges_helper import extract_challenges_for_programme_from_mongodb
 from lms.djangoapps.learning_success.management.commands.utils import get_students_programme_ids_and_lms_version
 from ci_program.models import Program
 
@@ -381,7 +381,7 @@ class Command(BaseCommand):
             programme_components[programme.program_code] = harvest_programme(
                 programme)
             programme_challenges[programme.program_code
-                ] = extract_all_student_challenges(programme)
+                ] = extract_challenges_for_programme_from_mongodb(programme)
 
         fullstack_students = User.objects.filter(
             program__id__in=fullstack_programme_ids)


### PR DESCRIPTION
**Description:**
Since we moved to the new challenge platform we have not been exacting challenge data for AMOS. This will allow us to extract the data for AMOS from the mongodb instead of the LMS' database.

**Clickup Task:**
[Update management command to pull challenge data from the Mongo DB instead of the LMS](https://app.clickup.com/t/h725jd)

**Testing:**
Tested the export with multiple users.