### PR TITLE
Removing py2neo and fixing webpack issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,10 @@
     "uglify-js": "2.7.0",
     "underscore": "1.8.3",
     "underscore.string": "3.3.5",
-    "webpack": "^5.20.2",
-    "webpack-bundle-tracker": "^0.4.3",
+    "webpack": "3.12.0",
+    "webpack-bundle-tracker": "0.4.3",
     "webpack-merge": "4.1.1",
+    "webpack-cli": "3.3.10",
     "whatwg-fetch": "2.0.3",
     "which-country": "1.0.0"
   },

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -119,7 +119,6 @@ ora2
 pdfminer.six                        # Used in shoppingcart for extracting/parsing pdf text
 piexif                              # Exif image metadata manipulation, used in the profile_images app
 Pillow                              # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
-py2neo<4.0.0                        # Used to communicate with Neo4j, which is used internally for modulestore inspection
 PyContracts
 pycountry
 pycryptodomex

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -215,7 +215,6 @@ pip-tools==4.5.1          # via -c requirements/edx/../constraints.txt, -r requi
 pluggy==0.13.1            # via -r requirements/edx/testing.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/edx/testing.txt, edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/testing.txt, edx-django-utils
-py2neo==3.1.2             # via -r requirements/edx/testing.txt
 py==1.9.0                 # via -r requirements/edx/testing.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/edx/testing.txt, flake8
 pycontracts==1.8.12       # via -r requirements/edx/testing.txt, edx-user-state-client

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -206,7 +206,6 @@ pillow==7.2.0             # via -r requirements/edx/base.txt, edx-enterprise, ed
 pluggy==0.13.1            # via -r requirements/edx/coverage.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/base.txt, edx-django-utils
-py2neo==3.1.2             # via -r requirements/edx/base.txt
 py==1.9.0                 # via pytest, tox
 pycodestyle==2.6.0        # via -r requirements/edx/testing.in, flake8
 pycontracts==1.8.12       # via -r requirements/edx/base.txt, edx-user-state-client


### PR DESCRIPTION
**Description:**
Compiling the static files for updates in the lms-theme is currently broken. This seems due to the same issue we had with the `py2neo` package on prod, thus this PR removes this dependency from any of the requirements files.
Once that was fixed, there was another issue with `webpack` for node. This seemed to have been the case on prod as well, but was not noticed because we had not updated the theme recently. Changes to the versions of `webpack` and adding `webpack-cli` seems to fix the issues.

**Clickup Task:**
[Fix issue with not being able to run ./compile_static.sh](https://app.clickup.com/t/hv2dbg)

**Testing:**
- No errors in build anymore
- `compile_static.sh` runs successfully
- OpenEdx runs fine, can access programme page, units etc.