### PR TITLE
Adding decorator to the sysadmin panel to allow only staff to access

### DIFF
--- a/cms/djangoapps/contentstore/views/error.py
+++ b/cms/djangoapps/contentstore/views/error.py
@@ -6,7 +6,8 @@ from edxmako.shortcuts import render_to_response, render_to_string
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from util.views import fix_crum_request
 
-__all__ = ['not_found', 'server_error', 'render_404', 'render_500']
+__all__ = ['not_found', 'server_error', 'render_404', 'render_500',
+           'render_403']
 
 
 def jsonable_error(status=500, message="The Studio servers encountered an error"):
@@ -47,3 +48,9 @@ def render_404(request, exception):
 @jsonable_error(500, "The Studio servers encountered an error")
 def render_500(request):
     return HttpResponseServerError(render_to_string('500.html', {}, request=request))
+
+
+@fix_crum_request
+@jsonable_error(403, "You do not have permission to access this page")
+def render_403(request):
+    return HttpResponseServerError(render_to_string('403.html', {}, request=request))

--- a/cms/djangoapps/contentstore/views/error.py
+++ b/cms/djangoapps/contentstore/views/error.py
@@ -52,5 +52,5 @@ def render_500(request):
 
 @fix_crum_request
 @jsonable_error(403, "You do not have permission to access this page")
-def render_403(request):
+def render_403(request, exception):
     return HttpResponseServerError(render_to_string('403.html', {}, request=request))

--- a/cms/templates/403.html
+++ b/cms/templates/403.html
@@ -1,0 +1,29 @@
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<%inherit file="../main.html" />
+
+<%block name="pagetitle">${_("403 Forbidden")}</%block>
+
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="outside-app">
+        <h1>
+            <%block name="pageheader">${page_header or _("403 Forbidden")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">
+                % if page_content:
+                    ${page_content}
+                % else:
+                    ${Text(_('You do not have permission to access this page. Go back to the {link_start}homepage{link_end} .')).format(
+                    link_start=HTML('<a href="/">'),
+                    link_end=HTML('</a>')
+                    )}
+                % endif
+            </%block>
+        </p>
+    </section>
+</main>

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -30,6 +30,7 @@ if password_policy_compliance.should_enforce_compliance_on_login():
 # Custom error pages
 # These are used by Django to render these error codes. Do not remove.
 # pylint: disable=invalid-name
+handler403 = contentstore.views.render_403
 handler404 = contentstore.views.render_404
 handler500 = contentstore.views.render_500
 
@@ -286,6 +287,7 @@ urlpatterns.append(
 
 # display error page templates, for testing purposes
 urlpatterns += [
+    url(r'^403$', handler403),
     url(r'^404$', handler404),
     url(r'^500$', handler500),
 ]

--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -10,6 +10,7 @@ import calc
 import crum
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseForbidden, HttpResponseServerError
 from django.views.decorators.csrf import ensure_csrf_cookie, requires_csrf_token
 from django.views.defaults import server_error
@@ -77,11 +78,7 @@ def require_global_staff(func):
         if GlobalStaff().has_user(request.user):
             return func(request, *args, **kwargs)
         else:
-            return HttpResponseForbidden(
-                u"Must be {platform_name} staff to perform this action.".format(
-                    platform_name=settings.PLATFORM_NAME
-                )
-            )
+            raise PermissionDenied
     return login_required(wrapped)
 
 

--- a/lms/djangoapps/ci_program/utils.py
+++ b/lms/djangoapps/ci_program/utils.py
@@ -62,6 +62,7 @@ def get_student_deadlines_from_zoho_data(zoho_record):
         student_data.values(),
         key=lambda k: (k.get('submission_deadline') or ''))
 
+    print(sorted_student_data)
     for index, data in enumerate(sorted_student_data, start=1):
         data['name'] = "Milestone Project %s" % index
         data['overdue'] = is_overdue(data)

--- a/lms/djangoapps/ci_program/utils.py
+++ b/lms/djangoapps/ci_program/utils.py
@@ -62,7 +62,6 @@ def get_student_deadlines_from_zoho_data(zoho_record):
         student_data.values(),
         key=lambda k: (k.get('submission_deadline') or ''))
 
-    print(sorted_student_data)
     for index, data in enumerate(sorted_student_data, start=1):
         data['name'] = "Milestone Project %s" % index
         data['overdue'] = is_overdue(data)

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -44,6 +44,7 @@ from student.roles import CourseInstructorRole, CourseStaffRole
 from xmodule.modulestore.django import modulestore
 from ci_program.models import Program
 from student_enrollment.utils import get_or_register_student
+from util.views import require_global_staff
 
 log = logging.getLogger(__name__)
 
@@ -66,6 +67,7 @@ class SysadminDashboardView(TemplateView):
 
     @method_decorator(ensure_csrf_cookie)
     @method_decorator(login_required)
+    @method_decorator(require_global_staff)
     @method_decorator(cache_control(no_cache=True, no_store=True,
                                     must_revalidate=True))
     @method_decorator(condition(etag_func=None))

--- a/lms/djangoapps/static_template_view/tests/test_views.py
+++ b/lms/djangoapps/static_template_view/tests/test_views.py
@@ -71,6 +71,15 @@ class MarketingSiteViewTests(TestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp['Content-Type'], 'text/html')
+    
+    def test_403(self):
+        """
+        Test the 403 view.
+        """
+        url = reverse('static_template_view.views.render_403')
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp['Content-Type'], 'text/html')
 
     def test_500(self):
         """

--- a/lms/djangoapps/static_template_view/urls.py
+++ b/lms/djangoapps/static_template_view/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     # Semi-static views (these need to be rendered and have the login bar, but don't change)
     url(r'^404$', views.render, {'template': '404.html'}, name="404"),
     # display error page templates, for testing purposes
+    url(r'^404$', views.render_403, name='static_template_view.views.render_403'),
     url(r'^404$', views.render_404, name='static_template_view.views.render_404'),
     url(r'^500$', views.render_500, name='static_template_view.views.render_500'),
 

--- a/lms/djangoapps/static_template_view/views.py
+++ b/lms/djangoapps/static_template_view/views.py
@@ -10,6 +10,7 @@ import mimetypes
 
 from django.conf import settings
 from django.http import Http404, HttpResponseNotFound, HttpResponseServerError
+from django.http.response import HttpResponseForbidden
 from django.shortcuts import redirect
 from django.template import TemplateDoesNotExist
 from django.utils.safestring import mark_safe
@@ -101,3 +102,9 @@ def render_404(request, exception):
 @fix_crum_request
 def render_500(request):
     return HttpResponseServerError(render_to_string('static_templates/server-error.html', {}, request=request))
+
+
+@fix_crum_request
+def render_403(request, exception):
+    request.view_name = '403'
+    return HttpResponseForbidden(render_to_string('static_templates/403.html', {}, request=request))

--- a/lms/templates/static_templates/403.html
+++ b/lms/templates/static_templates/403.html
@@ -1,0 +1,29 @@
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<%inherit file="../main.html" />
+
+<%block name="pagetitle">${_("403 Forbidden")}</%block>
+
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="outside-app">
+        <h1>
+            <%block name="pageheader">${page_header or _("403 Forbidden")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">
+                % if page_content:
+                    ${page_content}
+                % else:
+                    ${Text(_('You do not have permission to access this page. Go back to the {link_start}homepage{link_end} .')).format(
+                    link_start=HTML('<a href="/">'),
+                    link_end=HTML('</a>')
+                    )}
+                % endif
+            </%block>
+        </p>
+    </section>
+</main>

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -70,8 +70,10 @@ if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
 # Custom error pages
 # These are used by Django to render these error codes. Do not remove.
 # pylint: disable=invalid-name
+handler403 = static_template_view_views.render_403
 handler404 = static_template_view_views.render_404
 handler500 = static_template_view_views.render_500
+
 
 notification_prefs_urls = [
     url(r'^notification_prefs/enable/', notification_prefs_views.ajax_enable),


### PR DESCRIPTION
**Description:**
To avoid student accessing the Sysadmin panel without permission this will only allow staff users to access the sysadmin panel.

**Task:**
[Learner accounts on the LMS can access the student enrollment via Sysadmin feature](https://app.clickup.com/t/yqdj60)