### PR TITLE
Replace Milestone Project with Project

### DIFF
--- a/lms/djangoapps/ci_program/tests.py
+++ b/lms/djangoapps/ci_program/tests.py
@@ -27,19 +27,19 @@ class ProjectDeadlinesUnitTest(TestCase):
         result = get_student_deadlines_from_zoho_data(self.api_data)
 
         self.assertEqual([
-            {'name': 'Milestone Project 1',
+            {'name': 'Project 1',
              'submission_deadline': '2020-09-01',
              'latest_submission': '{}',
              'overdue': False,
              'next_project': False},
 
-            {'name': 'Milestone Project 2',
+            {'name': 'Project 2',
              'submission_deadline': '2020-10-01',
              'latest_submission': None,
              'overdue': True,
              'next_project': False},
 
-            {'name': 'Milestone Project 3',
+            {'name': 'Project 3',
              'submission_deadline': '2020-11-01',
              'latest_submission': None,
              'overdue': False,
@@ -59,19 +59,19 @@ class ProjectDeadlinesUnitTest(TestCase):
         result = get_student_deadlines_from_zoho_data(self.api_data)
 
         self.assertEqual([
-            {'name': 'Milestone Project 1',
+            {'name': 'Project 1',
              'submission_deadline': '2020-09-01',
              'latest_submission': '{}',
              'overdue': False,
              'next_project': False},
 
-            {'name': 'Milestone Project 2',
+            {'name': 'Project 2',
              'submission_deadline': '2020-10-01',
              'latest_submission': '{}',
              'overdue': False,
              'next_project': False},
 
-            {'name': 'Milestone Project 3',
+            {'name': 'Project 3',
              'submission_deadline': '2020-11-01',
              'latest_submission': None,
              'overdue': False,

--- a/lms/djangoapps/ci_program/utils.py
+++ b/lms/djangoapps/ci_program/utils.py
@@ -63,7 +63,7 @@ def get_student_deadlines_from_zoho_data(zoho_record):
         key=lambda k: (k.get('submission_deadline') or ''))
 
     for index, data in enumerate(sorted_student_data, start=1):
-        data['name'] = "Milestone Project %s" % index
+        data['name'] = "Project %s" % index
         data['overdue'] = is_overdue(data)
         data['next_project'] = False
 


### PR DESCRIPTION
https://app.clickup.com/t/13nhrnd

Remove reference to 'Milestone' in Project deadlines on programme page. 

Students are completing Milestone and Portfolio projects now (depending upon the programme they are enrolled in) so this generalisation resolves confusion. 

Output when testing the change locally: 
![image](https://user-images.githubusercontent.com/24976693/126631249-a3dab01c-9cd7-4a83-9e29-f43880852a5a.png)
