### PR TITLE
five day coding challenge experiment - updating challenge exporter to accommodate new challenge content

### DIFF
--- a/lms/djangoapps/learning_success/export_coding_challenge_data.py
+++ b/lms/djangoapps/learning_success/export_coding_challenge_data.py
@@ -217,7 +217,7 @@ class CodeChallengeExporter:
         else HubSpot profiles for all other students
         """
         log.info(("Started export_coding_challenge_data for %s, with %s "
-                  "students and %s chalenges"),
+                  "students and %s challenges"),
                  self.program_code, len(self.students), len(self.challenges))
         results_for_all_students = self.get_results_for_all_students()
         if self.program_code == "lpcc":

--- a/lms/djangoapps/learning_success/export_coding_challenge_data.py
+++ b/lms/djangoapps/learning_success/export_coding_challenge_data.py
@@ -50,9 +50,9 @@ CODING_CHALLENGES_MAP = {
     # if successful, the challenges below will replace original challenges above
     "Challenge 1": "lesson_1_challenge_1",
     "Challenge 2": "lesson_1_challenge_2",
-    "Challenge 3": "lesson_2_challenge_1",
-    "Challenge 4": "lesson_2_challenge_2",
-    "Challenge 5": "lesson_2_challenge_3",
+    "Challenge 3": "lesson_2_challenge_2",
+    "Challenge 4": "lesson_2_challenge_3",
+    "Challenge 5": "lesson_2_challenge_4",
     "Challenge 6": "lesson_3_challenge_1",
     "Challenge 7": "lesson_3_challenge_2",
     "Challenge 8": "lesson_3_challenge_3",


### PR DESCRIPTION
Marketing want to run an experiment  to compare the success of new challenges created by Programme (i.e. Challenge 1, Challenge 2,.....Challenge 14) available on https://learn.codeinstitute.net/sandbox/challenges.

This means that we'll run programmes with the original programme and a new Five Day Coding Challenge programme with the new challenges concurrently. Marketing also require that we re-use the existing fields on HubSpot and LP Zoho CRM to report on student success in completing the new challenge content, rather than create new fields (creating new fields results in a delay and additional cost to get the experiment up and running, so they have opted to reuse existing fields available in HubSpot. I've made them aware that they won't have an easy way to differentiate on HubSpot between whether the results maps to an original or new challenge, and Rory is okay with managing/mitigating that (through student source / programme id filters instead). The mapping table of new challenges to challenge_results_fields on HubSpot is available here: https://github.com/Code-Institute-Org/edx-juniper/blob/02a36ba9f393fcdbb36b4863bcda91b0a19603d8/lms/djangoapps/learning_success/export_coding_challenge_data.py#L51

A new program has also been created for this experiment (program code: FDCC20210929) and is available here: https://learn.codeinstitute.net/ci_program/fiveday. 
More details on this programme available here (see pending deployment tab): https://docs.google.com/spreadsheets/d/1X9BcMhfyh60TMIcmoFWgi0S3bRT1boY-ZuWGlQTzYws/edit#gid=873160367

The target date for kicking off this experiment is Monday 15th November, so looking to deploy the latest changes here in the upcoming deployment on Wed 10 Nov. 

Once the script change is deployed, the final config step is to enable the new celery task on the LMS admin panel: available here: https://learn.codeinstitute.net/admin/djcelery/periodictask/15/change/