### PR TITLE
Removing this filter stops a server crash when the django SECRET_KEY …

### DIFF
--- a/openedx/core/lib/logsettings.py
+++ b/openedx/core/lib/logsettings.py
@@ -50,16 +50,12 @@ def get_logger_config(log_dir,
             'require_debug_false': {
                 '()': 'django.utils.log.RequireDebugFalse',
             },
-            'userid_context': {
-                '()': 'openedx.core.djangoapps.util.log_utils.UserIdFilter',
-            }
         },
         'handlers': {
             'console': {
                 'level': 'INFO',
                 'class': 'logging.StreamHandler',
                 'formatter': 'standard',
-                'filters': ['userid_context'],
                 'stream': sys.stderr,
             },
             'mail_admins': {


### PR DESCRIPTION
…is changed